### PR TITLE
Fix unit test

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,23 +13,20 @@ from ops.testing import Harness
 
 from charm import NginxCharm
 
+DEFAULT_CONFIG = {"host": uuid4(), "port": random.randint(10, 20)}
+STORED_CONFIG = {"host": uuid4(), "port": random.randint(10, 20), "publishes": {}}
+
 
 class TestCharm(unittest.TestCase):
-    def default_config(self):
-        return {"host": uuid4(), "port": random.randint(10, 20)}
-
-    def stored_config(self):
-        return {"host": uuid4(), "port": random.randint(10, 20), "publishes": {}}
-
     def test_config_changed(self):
         harness = Harness(NginxCharm)
         self.addCleanup(harness.cleanup)
         harness.begin()
         harness.charm._render_config = Mock()
         harness.charm._reload_config = Mock()
-        default_config = self.default_config()
-        harness.update_config(default_config)
-        default_config["publishes"] = {}
+        # default_config = DEFAULT_CONFIG
+        harness.update_config(DEFAULT_CONFIG)
+        default_config = {**DEFAULT_CONFIG, "publishes": {}}
         self.assertEqual(harness.charm._stored.config, default_config)
         self.assertTrue(harness.charm._render_config.called)
         self.assertTrue(harness.charm._reload_config.called)
@@ -145,15 +142,15 @@ class TestCharm(unittest.TestCase):
     def test_template_nginx_conf(self):
         with open("templates/nginx.conf.j2") as f:
             t = Template(f.read())
-        t.render(config=self.stored_config()).encode("UTF-8")
+        t.render(config=STORED_CONFIG).encode("UTF-8")
 
     def test_template_nginx_site_no_publish_conf(self):
         with open("templates/nginx-site.conf.j2") as f:
             t = Template(f.read())
-        t.render(config=self.stored_config()).encode("UTF-8")
+        t.render(config=STORED_CONFIG).encode("UTF-8")
 
     def test_template_nginx_site_publishes_conf(self):
-        config = self.stored_config()
+        config = STORED_CONFIG
         config["publishes"] = {str(uuid4()): str(uuid4())}
         with open("templates/nginx-site.conf.j2") as f:
             t = Template(f.read())

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,6 +16,9 @@ from charm import NginxCharm
 
 class TestCharm(unittest.TestCase):
     def default_config(self):
+        return {"host": uuid4(), "port": random.randint(10, 20)}
+
+    def stored_config(self):
         return {"host": uuid4(), "port": random.randint(10, 20), "publishes": {}}
 
     def test_config_changed(self):
@@ -26,6 +29,7 @@ class TestCharm(unittest.TestCase):
         harness.charm._reload_config = Mock()
         default_config = self.default_config()
         harness.update_config(default_config)
+        default_config["publishes"] = {}
         self.assertEqual(harness.charm._stored.config, default_config)
         self.assertTrue(harness.charm._render_config.called)
         self.assertTrue(harness.charm._reload_config.called)
@@ -141,15 +145,15 @@ class TestCharm(unittest.TestCase):
     def test_template_nginx_conf(self):
         with open("templates/nginx.conf.j2") as f:
             t = Template(f.read())
-        t.render(config=self.default_config()).encode("UTF-8")
+        t.render(config=self.stored_config()).encode("UTF-8")
 
     def test_template_nginx_site_no_publish_conf(self):
         with open("templates/nginx-site.conf.j2") as f:
             t = Template(f.read())
-        t.render(config=self.default_config()).encode("UTF-8")
+        t.render(config=self.stored_config()).encode("UTF-8")
 
     def test_template_nginx_site_publishes_conf(self):
-        config = self.default_config()
+        config = self.stored_config()
         config["publishes"] = {str(uuid4()): str(uuid4())}
         with open("templates/nginx-site.conf.j2") as f:
             t = Template(f.read())


### PR DESCRIPTION
Harness has added validation for checking config options' existence (commit [9a1a5d]), which causes error in the unittest. In fact, juju config change only accepts keys that are defined in config.yaml, so the test needs to reflect this.

[9a1a5d]: https://github.com/canonical/operator/commit/9a1ad5d9a5cd4b84fa40bcb4d9af37553c41b9df#