### PR TITLE
Add workflow to release the charm

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# This is a template `CODEOWNERS` file for ops charms
+# This file is managed by bootstack-charms-spec and should not be modified
+# within individual charm repos. https://launchpad.net/bootstack-charms-spec
+
+# For more information about CODEOWNER, please refer to
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence, @canonical/bootstack will be requested for
+# review when someone opens a pull request.
+*       @canonical/soleng-reviewers

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,25 @@
+# This is a template `release.yaml` file for ops charms
+# This file is managed by bootstack-charms-spec and should not be modified
+# within individual charm repos. https://launchpad.net/bootstack-charms-spec
+
+name: Release to Edge
+
+on:
+  push:
+    branches: [master, main]
+
+concurrency:
+  group: release
+  cancel-in-progress: true
+
+jobs:
+  check:
+    uses: ./.github/workflows/check.yaml
+
+  release:
+    needs: check
+    uses: canonical/bootstack-actions/.github/workflows/charm-release.yaml@v2
+    secrets: inherit
+    with:
+      channel: "latest/edge"
+      upload-image: false

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,17 @@
+# This is a template `sonar.yaml` file for ops charms
+# This file is managed by bootstack-charms-spec and should not be modified
+# within individual charm repos. https://launchpad.net/bootstack-charms-spec
+
+name: SonarCloud
+on:
+  workflow_run:
+    workflows: 
+      - PR workflow running lint checkers, unit and functional tests
+    types: [completed]
+
+jobs:
+  sonar:
+    uses: canonical/bootstack-actions/.github/workflows/sonar.yaml@main
+    secrets: inherit
+    with:
+      workflow-name: PR workflow running lint checkers, unit and functional tests


### PR DESCRIPTION
As part of migration from Launchpad to Github, a release workflow is added. The launchpad recipe can be deleted once this PR is merged and the release workflow works as expected.
This PR also adds a `CODEOWNERS` file and a `sonar.yaml` file for sonar integration.