### PR TITLE
ci: add missing TEST_JUJU3 in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ passenv =
   SNAP_HTTP_PROXY
   SNAP_HTTPS_PROXY
   OS_*
+  TEST_JUJU3
 
 [testenv:dev-environment]
 envdir = {toxinidir}/.venv


### PR DESCRIPTION
`tox.ini` is missing `TEST_JUJU3` in the `passenv` setting, that environment variable is used to determine whether or not we should use libjuju 2.x or libjuju 3.x