### PR TITLE
update release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,11 +15,27 @@ concurrency:
 jobs:
   check:
     uses: ./.github/workflows/check.yaml
+    secrets: inherit
 
   release:
     needs: check
-    uses: canonical/bootstack-actions/.github/workflows/charm-release.yaml@v3
-    secrets: inherit
-    with:
-      channel: "latest/edge"
-      upload-image: false
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize lxd  # This should dropped once it's implemented on charming-actions itself. https://github.com/canonical/charming-actions/issues/140
+        # revision is latest main at time of writing; using because it contains a fix to https://github.com/canonical/setup-lxd/issues/19
+        uses: canonical/setup-lxd@2aa6f7caf7d1484298a64192f7f63a6684e648a4
+
+      - name: Pack and upload to charmhub
+        uses: canonical/charming-actions/upload-charm@2.6.2
+        with:
+          charmcraft-channel: "2.x/stable"
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          # Ensure the charm is built in an isolated environment and on the correct base in an lxd container.
+          destructive-mode: false
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,6 @@ jobs:
 
   release:
     needs: check
-    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
 
   release:
     needs: check
-    uses: canonical/bootstack-actions/.github/workflows/charm-release.yaml@v2
+    uses: canonical/bootstack-actions/.github/workflows/charm-release.yaml@v3
     secrets: inherit
     with:
       channel: "latest/edge"


### PR DESCRIPTION
The removal of `metadata.yaml` caused the release workflow to fail because `charm-release.yaml@v2` relies on [upload-charm@2.4.0](https://github.com/canonical/charming-actions/blob/631c2d944da2bd12430f1f3a954c8fffcf2385cd/dist/upload-charm/index.js#L22934), which requires the presence of `metadata.yaml`.
Update the workflow to to use `upload-charm@2.6.2`. This newer version does not require `metadata.yaml`, which should fix the issue.